### PR TITLE
Add tools for viewing difference in linker output between runs

### DIFF
--- a/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
@@ -1,0 +1,78 @@
+package edu.knowitall.main
+
+import edu.knowitall.repr.sentence.Sentence
+import edu.knowitall.repr.document.Document
+import edu.knowitall.repr.document.Sentenced
+import edu.knowitall.tool.link.OpenIELinked
+import edu.knowitall.repr.link.FreeBaseLink
+import edu.knowitall.repr.link.Link
+import edu.knowitall.tool.document.OpenIEBaselineExtractor
+import edu.knowitall.tool.document.OpenIEDocumentExtractor
+
+object LinkDiffPrinter extends App {
+  
+  type LinkedDocument = Document with Sentenced[_ <: Sentence] with OpenIELinked
+  
+  import DocOpenIEMain.loadSentencedDocs
+  
+  val sentencedDocuments = loadSentencedDocs(args(0))
+  
+  val baseLineExtractor = new OpenIEBaselineExtractor()
+  val fullExtractor = new OpenIEDocumentExtractor()
+  
+  val baseLineExtracted = sentencedDocuments map (kd => kd.copy(doc=baseLineExtractor.extract(kd.doc)))
+  val fullExtracted = sentencedDocuments map (kd => kd.copy(doc=fullExtractor.extract(kd.doc)))
+  
+  val psout = new java.io.PrintStream(args(1))
+  val diffPrinter = new LinkDiffPrinter(psout)
+  psout.println(diffPrinter.columnHeaderString)
+  baseLineExtracted.zip(fullExtracted).map { case (base, full) =>
+    diffPrinter.print(base.asInstanceOf[LinkedDocument], full.asInstanceOf[LinkedDocument])  
+  }
+  psout.flush()
+  psout.close()
+}
+
+class LinkDiffPrinter(out: java.io.PrintStream) {
+
+  import LinkDiffPrinter.LinkedDocument  
+  
+  def print(oldDoc: LinkedDocument, newDoc: LinkedDocument): Unit = {
+    
+    val oldLinks = oldDoc.links.toSet
+    val newLinks = newDoc.links.toSet
+    
+    val oldDiff = oldLinks &~ newLinks
+    val newDiff = newLinks &~ oldLinks
+    
+    // old links are paired with "true", new links "false".
+    val combined = (oldDiff.map((true, _)) ++ newDiff.map((false, _)))
+    // sort by offset
+    val sorted = combined.toSeq.sortBy(_._2.offset)
+    
+    sorted foreach { case (oldFlag, link) =>
+      out.println(diffString(oldFlag, link))
+    }
+  } 
+  
+  val columnHeaders = Seq("SOURCE", "OFFSET", "WIKI TITLE", "FB ID", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE")
+  val columnHeaderString = columnHeaders.mkString("\t")
+  
+  def diffString(old: Boolean, link: FreeBaseLink): String = {
+    val diffType = if (old) "BASELINE" else "NEW"
+    diffType + "\t" + linkString(link)
+  }
+  
+  def linkString(l: Link): String = {
+    
+    def fmt(d: Double) = "%.02f" format d
+    
+    l match {
+        case f: FreeBaseLink =>
+          val types = f.types.take(2).mkString(", ") + ", ..."
+          val fields = Seq(f.offset, f.name, f.id, types, fmt(f.score), fmt(f.docSimScore), fmt(f.inlinks), fmt(f.candidateScore))
+          fields.mkString("\t")
+        case _ => s"(l.offset)\t${l.toString}"
+    }
+  }
+}

--- a/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
@@ -11,7 +11,7 @@ import edu.knowitall.tool.document.OpenIEDocumentExtractor
 
 object LinkDiffPrinter extends App {
   
-  type LinkedDocument = Document with Sentenced[_ <: Sentence] with OpenIELinked
+  
   
   import DocOpenIEMain.loadSentencedDocs
   
@@ -27,7 +27,7 @@ object LinkDiffPrinter extends App {
   val diffPrinter = new LinkDiffPrinter(psout)
   psout.println(diffPrinter.columnHeaderString)
   baseLineExtracted.zip(fullExtracted).map { case (base, full) =>
-    diffPrinter.print(base.asInstanceOf[LinkedDocument], full.asInstanceOf[LinkedDocument])  
+    diffPrinter.print(base.doc, full.doc)  
   }
   psout.flush()
   psout.close()
@@ -35,7 +35,7 @@ object LinkDiffPrinter extends App {
 
 class LinkDiffPrinter(out: java.io.PrintStream) {
 
-  import LinkDiffPrinter.LinkedDocument  
+  type LinkedDocument = Document with Sentenced[_ <: Sentence] with OpenIELinked  
   
   def print(oldDoc: LinkedDocument, newDoc: LinkedDocument): Unit = {
     

--- a/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
+++ b/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
@@ -24,6 +24,9 @@ import edu.knowitall.tool.bestentitymention.BestEntityMentionFinderOriginalAlgor
 
 class OpenIEDocumentExtractor {
 
+  type InputDoc = Document with Sentenced[_ <: Sentence]
+  type OutputDoc = Document with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound
+  
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
@@ -60,6 +63,9 @@ class OpenIEDocumentExtractor {
 
 class OpenIENoCorefDocumentExtractor {
 
+  type InputDoc = Document with Sentenced[_ <: Sentence]
+  type OutputDoc = Document with OpenIELinked with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound
+  
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
@@ -94,6 +100,9 @@ class OpenIENoCorefDocumentExtractor {
 
 class OpenIEBaselineExtractor {
 
+  type InputDoc = Document with Sentenced[_ <: Sentence]
+  type OutputDoc = Document with OpenIELinked with Sentenced[Sentence with OpenIEExtracted]  
+  
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()


### PR DESCRIPTION
Right now two links are "different" if they linked to different text or have a different link ID, but links that are identical except for their score are not different. Under this method, very few links seem to change between our baseline and "full" configurations -- I need to take a closer look at why.
