### PR TITLE
Coref best entity mention finding

### DIFF
--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -54,12 +54,12 @@ object DocOpenIEMain {
     }
     val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc)))
 
-    val outFile = new File("./output-corefExpanded.txt")
+    val outFile = new File("./output-103013corefExpanded.txt")
     val psout = new java.io.PrintStream(outFile)
     val evalPrinter = new EvaluationPrinter(psout)
     evalPrinter.printColumnHeaderString()
     extractedDocuments.foreach { ed =>
-      evalPrinter.printFull(ed)
+      evalPrinter.printCoref(ed)
     }
     psout.flush()
     System.err.println("Total extractions: " + extractedDocuments.flatMap(_.doc.sentences.map(_.sentence.extractions)).size)

--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -60,7 +60,7 @@ object DocOpenIEMain {
 
     val sentencedDocuments = loadSentencedDocs(args(0))
 
-    val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc)))
+    val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc,false)))
 
     val outFile = new File("./output-103013corefExpanded.txt")
     val psout = new java.io.PrintStream(outFile)

--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -18,6 +18,7 @@ import edu.knowitall.repr.document.Sentenced
 import edu.knowitall.tool.document.OpenIEDocumentExtractor
 import edu.knowitall.tool.document.OpenIEBaselineExtractor
 import edu.knowitall.tool.document.OpenIENoCorefDocumentExtractor
+import edu.knowitall.tool.document.OpenIECorefExpandedDocumentExtractor
 
 case class KbpDocument[D <: Document](val doc: D, val docId: String)
 
@@ -25,7 +26,7 @@ object DocOpenIEMain {
 
   val kbpSentencer = Sentencer.defaultInstance
 
-  val docExtractor = new OpenIEDocumentExtractor()
+  val docExtractor = new OpenIECorefExpandedDocumentExtractor()
 
  /**
   * Usage: provide path to KBP sample documents.
@@ -51,10 +52,9 @@ object DocOpenIEMain {
       }
       KbpDocument(doc, procDoc.extractDocId.get)
     }
-
     val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc)))
 
-    val outFile = new File("./output.txt")
+    val outFile = new File("./output-corefExpanded.txt")
     val psout = new java.io.PrintStream(outFile)
     val evalPrinter = new EvaluationPrinter(psout)
     evalPrinter.printColumnHeaderString()

--- a/src/main/scala/edu/knowitall/main/EvaluationPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/EvaluationPrinter.scala
@@ -17,6 +17,8 @@ import edu.knowitall.tool.coref.CoreferenceResolver
 import edu.knowitall.tool.bestentitymention.BestEntityMentionsFound
 import edu.knowitall.repr.bestentitymention.BestEntityMention
 import edu.knowitall.collection.immutable.Interval
+import edu.knowitall.repr.bestentitymention.BestEntityMentionResolvedDocument
+import edu.knowitall.repr.link.LinkedDocument
 
 /**
  * Code for producing tab-delimited output for human annotation and evaluation.
@@ -27,7 +29,7 @@ class EvaluationPrinter(out: java.io.PrintStream) {
 
   type SENT = Sentence with OpenIEExtracted
   type ExtractedSentenced = Sentenced[SENT]
-  type FullTraits = OpenIELinked with ExtractedSentenced with BestEntityMentionsFound
+  type FullTraits = LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with ExtractedSentenced with BestEntityMentionResolvedDocument[BestEntityMention]
   type BaselineTraits = OpenIELinked with ExtractedSentenced
 
   val columnHeaders = Seq("Best Arg1", "Rel", "Best Arg2", "Original Arg1", "Original Arg2", "Sentence Text", "Arg1 Links", "Arg2 Links", "Arg1 Best Mentions", "Arg2 Best Mentions", "Doc ID", "Arg1 Changed?", "Arg2 Changed?")

--- a/src/main/scala/edu/knowitall/tool/bestentitymention/BestEntityMentionFinder.scala
+++ b/src/main/scala/edu/knowitall/tool/bestentitymention/BestEntityMentionFinder.scala
@@ -504,7 +504,7 @@ object BestEntityMentionFinderOriginalAlgorithm{
   private object AbbreviationData {
 
   val abbreviationMap =
-    Map( "AL" -> "Alabama",
+    Map("AL" -> "Alabama",
         "AK" -> "Alaska",
         "AZ" -> "Arizona",
         "AR" -> "Arkansas",
@@ -559,12 +559,12 @@ object BestEntityMentionFinderOriginalAlgorithm{
 
   private val stateAbbreviationPattern = """(\w+),\s([A-Za-z])\.?([A-Za-z])\.?$""".r
   private val stopWords = {
-    io.Source.fromFile(new File("/scratch/usr/rbart/git/BasicEntityMentionFinder/src/main/resources/edu/washington/knowitall/entitymentionfinder/eval/stopwords.txt"))(scala.io.Codec.UTF8).getLines.flatMap(_.split(",")).map(_.toLowerCase).toSet
+    io.Source.fromFile(new File("/scratch2/code/jgilme1/UWELExpanded/src/main/resources/edu/knowitall/entitylinking/extended/utils/stopwords.txt"))(scala.io.Codec.UTF8).getLines.flatMap(_.split(",")).map(_.toLowerCase).toSet
   }
 
   private object TipsterData {
 
-  private val tipsterFile = new File("/scratch/usr/rbart/git/Tac2013EntityLinking/src/main/resources/edu/knowitall/tac2013/entitylinking/TipsterGazetteer.txt")
+  private val tipsterFile = new File("/scratch2/code/jgilme1/UWELExpanded/src/main/resources/edu/knowitall/entitylinking/extended/utils/TipsterGazetteer.txt")
   private val cityProvincePattern = """([^\(]+)\(CITY.+?([^\(\)]+)\(PROVINCE.*""".r
   private val cityCountryPattern = """([^\(]+)\(CITY.+?([^\(\)]+)\(COUNTRY.*""".r
 

--- a/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
+++ b/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
@@ -185,7 +185,7 @@ class OpenIECorefExpandedDocumentExtractor {
     for(m <- cluster.mentions; if m.isPronoun) yield BestEntityMention(m.text,m.offset,bestName)
   }
   
-  def extract(d: Document with Sentenced[_ <: Sentence]): Document with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention] = {
+  def extract(d: Document with Sentenced[_ <: Sentence], debug: Boolean): Document with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention] = {
 
     val preppedSentences = d.sentences.map { case DocumentSentence(sentence, offset) =>
       DocumentSentence(prepSentence(sentence), offset)
@@ -197,14 +197,16 @@ class OpenIECorefExpandedDocumentExtractor {
       val linker = entityLinker
       val bestEntityMentionFinder = bestEntityMentionFinderAlgorithm
     }
-    println("Document : " + d.sentences.head)
-    println("All links in Doc: ")
-    for(link <- doc.links){
-      println(link.offset + "\t" + link.name)
-    }
-    println("All BEMS in Doc: ")
-    for(bem <- doc.bestEntityMentions){
-      println(bem.offset + "\t" + bem.bestEntityMention)
+    if(debug){
+	    println("Document : " + d.sentences.head)
+	    println("All links in Doc: ")
+	    for(link <- doc.links){
+	      println(link.offset + "\t" + link.name)
+	    }
+	    println("All BEMS in Doc: ")
+	    for(bem <- doc.bestEntityMentions){
+	      println(bem.offset + "\t" + bem.bestEntityMention)
+	    }
     }
     var corefExpandedBestEntityMentions = doc.bestEntityMentions
     var clusterIndex =1
@@ -213,18 +215,20 @@ class OpenIECorefExpandedDocumentExtractor {
       val links = getUniqueLinksInCluster(cluster,doc.links)
       val bestEntityMentions = getUniqueBestEntityMentionsInCluster(cluster, doc.bestEntityMentions)
       var bestName :Option[String] = None
-      println("Cluster number " + clusterIndex)
-      println("Mentions: ")
-      for(mention <- mentions){
-        println(mention.offset + "\t" + mention.text + "\t" + mention.isPronoun)
-      }
-      println("Unique links: ")
-      for(l <- links){
-        println(l.offset + "\t" + l.name)
-      }
-      println("Unique BEMS: ")
-      for(bem <- bestEntityMentions){
-        println(bem.offset + "\t" + bem.bestEntityMention)
+      if(debug){
+	      println("Cluster number " + clusterIndex)
+	      println("Mentions: ")
+	      for(mention <- mentions){
+	        println(mention.offset + "\t" + mention.text + "\t" + mention.isPronoun)
+	      }
+	      println("Unique links: ")
+	      for(l <- links){
+	        println(l.offset + "\t" + l.name)
+	      }
+	      println("Unique BEMS: ")
+	      for(bem <- bestEntityMentions){
+	        println(bem.offset + "\t" + bem.bestEntityMention)
+	      }
       }
       if(links.length ==1)  {
         bestName = Some(links.head.name)
@@ -238,11 +242,13 @@ class OpenIECorefExpandedDocumentExtractor {
       }
       clusterIndex += 1
     }
-    println("New BEMS:")
-    for(newMention <- corefExpandedBestEntityMentions){
-      if(doc.bestEntityMentions.forall(p => p.offset != newMention.offset)){
-        println(newMention.offset +"\t" + newMention.bestEntityMention)
-      }
+    if(debug){
+	    println("New BEMS:")
+	    for(newMention <- corefExpandedBestEntityMentions){
+	      if(doc.bestEntityMentions.forall(p => p.offset != newMention.offset)){
+	        println(newMention.offset +"\t" + newMention.bestEntityMention)
+	      }
+	    }
     }
     val newDoc = new Document(d.text) with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention]{
       val links = doc.links

--- a/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
+++ b/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
@@ -21,13 +21,17 @@ import edu.knowitall.browser.entity.EntityLinker
 import java.io.File
 import edu.knowitall.tool.bestentitymention.BestEntityMentionsFound
 import edu.knowitall.tool.bestentitymention.BestEntityMentionFinderOriginalAlgorithm
+import edu.knowitall.repr.link.LinkedDocument
+import edu.knowitall.repr.link.FreeBaseLink
+import edu.knowitall.repr.bestentitymention.BestEntityMentionResolvedDocument
+import edu.knowitall.repr.bestentitymention.BestEntityMention
+import edu.knowitall.repr.coref.MentionCluster
 
 class OpenIEDocumentExtractor {
-
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
-  val entityLinker = new EntityLinker(new File("/scratch/"))
+  val entityLinker = new EntityLinker(new File("/scratch/resources/entitylinkingResources/"))
   val stanfordResolver = new StanfordCorefResolver()
   val bestEntityMentionFinderAlgorithm = new BestEntityMentionFinderOriginalAlgorithm()
 
@@ -120,5 +124,122 @@ class OpenIEBaselineExtractor {
       val sentences = preppedSentences
       val linker = entityLinker
     }
+  }
+}
+
+class OpenIECorefExpandedDocumentExtractor {
+  val parser = new ClearParser()
+  val chunker = new OpenNlpChunker()
+  val stemmer = new MorphaStemmer()
+  val entityLinker = new EntityLinker(new File("/scratch/resources/entitylinkingResources/"))
+  val stanfordResolver = new StanfordCorefResolver()
+  val bestEntityMentionFinderAlgorithm = new BestEntityMentionFinderOriginalAlgorithm()
+
+
+  def prepSentence(s: Sentence): Sentence with OpenIEExtracted = {
+    val parse = parser(s.text)
+    val postokens = parse.nodes.toSeq
+    val chunkTokens = chunker.chunkPostagged(postokens)
+    new Sentence(s.text) with OpenIEExtracted with Parsed with Chunked with Lemmatized {
+      override val lemmatizedTokens = chunkTokens map stemmer.stemToken
+      override val dgraph = parse
+      override val tokens = chunkTokens
+    }
+  }
+  
+  def getUniqueLinksInCluster(cluster: MentionCluster[Mention], links : Seq[FreeBaseLink]): Seq[FreeBaseLink] = {
+    var linksInCluster = Seq[FreeBaseLink]()
+    for(m <- cluster.mentions){
+      for(link <- links){
+        if(link.offset == m.offset){
+          linksInCluster = linksInCluster :+ link
+        }
+      }
+    }
+    linksInCluster.groupBy(f => f.id).values.map(f => f.head).toSeq
+  }
+  
+  def getUniqueBestEntityMentionsInCluster(cluster: MentionCluster[Mention], bestEntityMentions: Seq[BestEntityMention]): Seq[BestEntityMention] = {
+    var bestEntityMentionsInCluster = Seq[BestEntityMention]()
+    for(m <- cluster.mentions){
+      for(bem <- bestEntityMentions){
+        if(bem.offset == m.offset){
+          bestEntityMentionsInCluster = bestEntityMentionsInCluster :+ bem
+        }
+      }
+    }
+    bestEntityMentionsInCluster.groupBy(f => f.bestEntityMention).values.map(f => f.head).toSeq
+  }
+  
+  def makeNewBestEntityMentionsForPronounsInCluster(cluster: MentionCluster[Mention], bestName: String) = {
+    for(m <- cluster.mentions; if m.isPronoun) yield BestEntityMention(m.text,m.offset,bestName)
+  }
+  
+  def extract(d: Document with Sentenced[_ <: Sentence]): Document with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention] = {
+
+    val preppedSentences = d.sentences.map { case DocumentSentence(sentence, offset) =>
+      DocumentSentence(prepSentence(sentence), offset)
+    }
+
+    val doc  = new Document(d.text) with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound {
+      val clusters = stanfordResolver.resolve(d)
+      val sentences = preppedSentences
+      val linker = entityLinker
+      val bestEntityMentionFinder = bestEntityMentionFinderAlgorithm
+    }
+    println("Document : " + d.sentences.head)
+    println("All links in Doc: ")
+    for(link <- doc.links){
+      println(link.offset + "\t" + link.name)
+    }
+    println("All BEMS in Doc: ")
+    for(bem <- doc.bestEntityMentions){
+      println(bem.offset + "\t" + bem.bestEntityMention)
+    }
+    var corefExpandedBestEntityMentions = doc.bestEntityMentions
+    var clusterIndex =1
+    for(cluster <- doc.clusters){
+      val mentions = cluster.mentions
+      val links = getUniqueLinksInCluster(cluster,doc.links)
+      val bestEntityMentions = getUniqueBestEntityMentionsInCluster(cluster, doc.bestEntityMentions)
+      var bestName :Option[String] = None
+      println("Cluster number " + clusterIndex)
+      println("Mentions: ")
+      for(mention <- mentions){
+        println(mention.offset + "\t" + mention.text + "\t" + mention.isPronoun)
+      }
+      println("Unique links: ")
+      for(l <- links){
+        println(l.offset + "\t" + l.name)
+      }
+      println("Unique BEMS: ")
+      for(bem <- bestEntityMentions){
+        println(bem.offset + "\t" + bem.bestEntityMention)
+      }
+      if(links.length ==1)  {
+        bestName = Some(links.head.name)
+      }
+      else if(bestEntityMentions.length ==1) {
+        bestName = Some(bestEntityMentions.head.bestEntityMention)
+      }
+      if(bestName.isDefined){
+        val newBestEntityMentions = makeNewBestEntityMentionsForPronounsInCluster(cluster,bestName.get)
+        corefExpandedBestEntityMentions = corefExpandedBestEntityMentions ++ newBestEntityMentions
+      }
+      clusterIndex += 1
+    }
+    println("New BEMS:")
+    for(newMention <- corefExpandedBestEntityMentions){
+      if(doc.bestEntityMentions.forall(p => p.offset != newMention.offset)){
+        println(newMention.offset +"\t" + newMention.bestEntityMention)
+      }
+    }
+    val newDoc = new Document(d.text) with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention]{
+      val links = doc.links
+      val clusters = doc.clusters
+      val sentences = doc.sentences
+      val bestEntityMentions = corefExpandedBestEntityMentions.toSeq
+    }
+    newDoc
   }
 }


### PR DESCRIPTION
Coref Expansion works by looking for unique BEMs or Links in a cluster and then assigning these names as BEMs to all other pronouns in the cluster.
