### PR TITLE
Improve link-diff output to include original linker context

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 javaOptions += "-Xmx4G"
 
-javaOptions ++= Seq("-XX:+UseConcMarkSweepGC", "-Xmx4G", "-Xss512m")
+javaOptions ++= Seq("-XX:+UseConcMarkSweepGC", "-Xmx8G", "-Xss512m")
 
 fork in run := true
 

--- a/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
@@ -8,26 +8,25 @@ import edu.knowitall.repr.link.FreeBaseLink
 import edu.knowitall.repr.link.Link
 import edu.knowitall.tool.document.OpenIEBaselineExtractor
 import edu.knowitall.tool.document.OpenIEDocumentExtractor
+import edu.knowitall.tool.document.OpenIENoCorefDocumentExtractor
 
 object LinkDiffPrinter extends App {
-  
-  
-  
+
   import DocOpenIEMain.loadSentencedDocs
-  
+
   val sentencedDocuments = loadSentencedDocs(args(0))
-  
+
   val baseLineExtractor = new OpenIEBaselineExtractor()
   val fullExtractor = new OpenIEDocumentExtractor()
-  
+
   val baseLineExtracted = sentencedDocuments map (kd => kd.copy(doc=baseLineExtractor.extract(kd.doc)))
   val fullExtracted = sentencedDocuments map (kd => kd.copy(doc=fullExtractor.extract(kd.doc)))
-  
+
   val psout = new java.io.PrintStream(args(1))
   val diffPrinter = new LinkDiffPrinter(psout)
   psout.println(diffPrinter.columnHeaderString)
   baseLineExtracted.zip(fullExtracted).map { case (base, full) =>
-    diffPrinter.print(base, full)  
+    diffPrinter.print(base, full)
   }
   psout.flush()
   psout.close()
@@ -35,47 +34,53 @@ object LinkDiffPrinter extends App {
 
 class LinkDiffPrinter(out: java.io.PrintStream) {
 
-  type LinkedDocument = KbpDocument[_ <: Document with Sentenced[_ <: Sentence] with OpenIELinked]  
-  
+  type LinkedDocument = KbpDocument[_ <: Document with Sentenced[_ <: Sentence] with OpenIELinked]
+
   // links are distinct given an offset, the text they linked to, and their link ID.
   private def linkKey(l: FreeBaseLink) = (l.offset, l.text, l.id)
-  
+
   def print(oldDoc: LinkedDocument, newDoc: LinkedDocument): Unit = {
-    
+
     require(oldDoc.docId.equals(newDoc.docId), "Link diff should be for the same doc.")
-    
+
     val oldLinks = oldDoc.doc.links.map(l => (linkKey(l), l)).toMap
     val newLinks = newDoc.doc.links.map(l => (linkKey(l), l)).toMap
-    
+
     val oldDiff = (oldLinks -- newLinks.keys).toSeq
     val newDiff = (newLinks -- oldLinks.keys).toSeq
-    
+
     // old links are paired with "true", new links "false".
     val combined = (oldDiff.map((true, _)) ++ newDiff.map((false, _)))
     // sort by offset
     val sorted = combined.toSeq.sortBy(_._2._2.offset)
-    
+
     sorted foreach { case (oldFlag, (key, link)) =>
-      out.println(diffString(oldFlag, link, oldDoc.docId))
+      out.println(diffString(oldFlag, link, { if (oldFlag) oldDoc else newDoc }))
     }
-  } 
-  
-  val columnHeaders = Seq("SOURCE", "OFFSET", "WIKI TITLE", "FB ID", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE", "DOC ID")
-  val columnHeaderString = columnHeaders.mkString("\t")
-  
-  def diffString(old: Boolean, link: FreeBaseLink, docId: String): String = {
-    val diffType = if (old) "BASELINE" else "NEW"
-    diffType + "\t" + linkString(link) + "\t" + docId
   }
-  
+
+  val columnHeaders = Seq("SOURCE", "OFFSET", "ORIGINAL TEXT", "WIKI TITLE", "FB ID", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE", "CONTEXT", "DOC ID")
+  val columnHeaderString = columnHeaders.mkString("\t")
+
+  def diffString(old: Boolean, link: FreeBaseLink, kbpDoc: LinkedDocument): String = {
+    val context = kbpDoc.doc.argContexts.find { case (arg, _, context) =>
+      val offsetsMatch = link.offset == arg.offset + context.source.offset
+      val textMatch = link.text == arg.text
+      offsetsMatch && textMatch
+    }
+    val contextString = context.map(_._3.fullText.mkString("[", ", ", "]")).getOrElse("CONTEXT NOT FOUND")
+    val diffType = if (old) "BASELINE" else "NEW"
+    diffType + "\t" + linkString(link) + "\t" + contextString + "\t" + kbpDoc.docId
+  }
+
   def linkString(l: Link): String = {
-    
+
     def fmt(d: Double) = "%.02f" format d
-    
+
     l match {
         case f: FreeBaseLink =>
           val types = f.types.take(2).mkString(", ") + { if (f.types.size > 2) ", ..." else "" }
-          val fields = Seq(f.offset, f.name, f.id, types, fmt(f.score), fmt(f.docSimScore), fmt(f.inlinks), fmt(f.candidateScore))
+          val fields = Seq(f.offset, f.text, f.name, f.id, types, fmt(f.score), fmt(f.docSimScore), fmt(f.inlinks), fmt(f.candidateScore))
           fields.mkString("\t")
         case _ => s"(l.offset)\t${l.toString}"
     }

--- a/src/main/scala/edu/knowitall/repr/extraction/Extraction.scala
+++ b/src/main/scala/edu/knowitall/repr/extraction/Extraction.scala
@@ -27,18 +27,18 @@ object Extraction {
 
   def fromRelnoun(inst: BinaryExtractionInstance[ChunkedToken], confidence: Double): Extraction = {
     val rel = ExtractionPartImpl(inst.extr.rel.text, inst.extr.rel.offsetInterval.start, inst.extr.rel.tokenInterval)
-    val arg1 = ExtractionPartImpl(inst.extr.arg1.text, inst.extr.arg1.offsetInterval.start, inst.extr.arg1.tokenInterval)
-    val arg2 = ExtractionPartImpl(inst.extr.arg2.text, inst.extr.arg2.offsetInterval.start, inst.extr.arg2.tokenInterval)
+    val arg1 = ExtractionPartImpl(inst.extr.arg1.text, inst.extr.arg1.tokens.head.offset, inst.extr.arg1.tokenInterval)
+    val arg2 = ExtractionPartImpl(inst.extr.arg2.text, inst.extr.arg2.tokens.head.offset, inst.extr.arg2.tokenInterval)
     ExtractionImpl(arg1, rel, arg2, confidence)
   }
 
   def fromSrlie(inst: SrlExtractionInstance, confidence: Double): Seq[Extraction] = {
     def tokenIndices(part: SrlExtraction.MultiPart) = part.intervals.flatten
     inst.triplize(true).filterNot(_.extr.arg2s.isEmpty).flatMap { inst =>
-      val rel = ExtractionPartImpl(inst.extr.rel.text, inst.extr.rel.intervals.flatten.min, inst.extr.rel.tokenIntervals.flatten)
-      val arg1 = ExtractionPartImpl(inst.extr.arg1.text, inst.extr.arg1.interval.start, inst.extr.arg1.tokenInterval)
+      val rel = ExtractionPartImpl(inst.extr.rel.text, inst.extr.rel.tokens.map(_.offset).min, inst.extr.rel.tokenIntervals.flatten)
+      val arg1 = ExtractionPartImpl(inst.extr.arg1.text, inst.extr.arg1.tokens.head.offset, inst.extr.arg1.tokenInterval)
       inst.extr.arg2s.map { arg2 =>
-        ExtractionImpl(arg1, rel, ExtractionPartImpl(arg2.text, arg2.interval.start, arg2.tokenInterval), confidence)
+        ExtractionImpl(arg1, rel, ExtractionPartImpl(arg2.text, arg2.tokens.head.offset, arg2.tokenInterval), confidence)
       }
     }
   }

--- a/src/main/scala/edu/knowitall/tool/link/Linker.scala
+++ b/src/main/scala/edu/knowitall/tool/link/Linker.scala
@@ -30,9 +30,9 @@ trait Linker {
 trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
   this: Document with Sentenced[Sentence with OpenIEExtracted] =>
 
-  val minCombinedScore = 0
+  val minCombinedScore = 4.5
 
-  private case class Context(source: DocumentSentence[Sentence with OpenIEExtracted], extended: Seq[DocumentSentence[Sentence with OpenIEExtracted]]) {
+  case class Context(source: DocumentSentence[Sentence with OpenIEExtracted], extended: Seq[DocumentSentence[Sentence with OpenIEExtracted]]) {
     def fullText = (source +: extended).distinct.map(_.sentence.text)
   }
 
@@ -51,11 +51,11 @@ trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
     if (tokens.lastOption.exists(t => t.isDeterminer || t.isPreposition)) tokens = tokens.dropRight(1)
     tokens.map(_.string).mkString(" ")
   }
-  
+
   /**
    * Pairs of (argument, context)
    */
-  private lazy val argContexts = this.sentences.flatMap { s =>
+  lazy val argContexts = this.sentences.flatMap { s =>
     val args = s.sentence.extractions.flatMap(e => e.arg1 :: e.arg2 :: Nil)
     val cleanArgs = args map cleanArg(s.sentence)
     args.zip(cleanArgs).map { case (arg, cleaned) =>


### PR DESCRIPTION
I also set the score threshold to give about 50% total yield, but we'll probably be changing this depending on what we're experimenting with. 
