### PR TITLE
Improve context collection for linker

### DIFF
--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -26,10 +26,10 @@ object DocOpenIEMain {
 
   val kbpSentencer = Sentencer.defaultInstance
 
-  val docExtractor = new OpenIECorefExpandedDocumentExtractor()
+  val docExtractor = new OpenIEDocumentExtractor()
 
   def loadKbpDocs(path: String): Seq[(File, KbpRawDoc, KbpProcessedDoc)] = {
-    
+
     val docPath = new File(path)
 
     val docFiles = docPath.listFiles().filter(_.getName().endsWith("sgm"))
@@ -38,7 +38,7 @@ object DocOpenIEMain {
 
     rawDocs map { case (file, doc) => (file, doc, processDoc(file, doc)) }
   }
-  
+
   def loadSentencedDocs(path: String) = {
     loadKbpDocs(path).toSeq.map { case (file, rawDoc, procDoc) =>
       val text = rawDoc.getString
@@ -52,7 +52,7 @@ object DocOpenIEMain {
       KbpDocument(doc, procDoc.extractDocId.get)
     }
   }
-  
+
  /**
   * Usage: provide path to KBP sample documents.
   */
@@ -60,7 +60,7 @@ object DocOpenIEMain {
 
     val sentencedDocuments = loadSentencedDocs(args(0))
 
-    val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc,false)))
+    val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc)))
 
     val outFile = new File("./output-103013corefExpanded.txt")
     val psout = new java.io.PrintStream(outFile)

--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -75,7 +75,6 @@ object DocOpenIEMain {
     System.err.println("Linked extractions (arg1 or arg2): " + evalPrinter.extractionsLinked)
     System.err.println("Best-Mention resolved extractions, arg1 or arg2: " + evalPrinter.extractionsResolved)
     psout.close()
-
   } { timeNs => System.err.println("Processing time: %s".format(Timing.Seconds.format(timeNs))) }
 
   def processDoc(file: File, rawDoc: KbpRawDoc): KbpProcessedDoc = {

--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -62,7 +62,7 @@ object DocOpenIEMain {
 
     val extractedDocuments = sentencedDocuments map (kd => kd.copy(doc=docExtractor.extract(kd.doc)))
 
-    val outFile = new File("./output-103013corefExpanded.txt")
+    val outFile = new File(args(1))
     val psout = new java.io.PrintStream(outFile)
     val evalPrinter = new EvaluationPrinter(psout)
     evalPrinter.printColumnHeaderString()

--- a/src/main/scala/edu/knowitall/main/EvaluationPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/EvaluationPrinter.scala
@@ -31,10 +31,10 @@ class EvaluationPrinter(out: java.io.PrintStream) {
 
   type SENT = Sentence with OpenIEExtracted
   type ExtractedSentenced = Sentenced[SENT]
-  type CorefTraits = LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with ExtractedSentenced with BestEntityMentionResolvedDocument[BestEntityMention]
+  type CorefTraits = LinkedDocument[FreeBaseLink] with CorefResolved with ExtractedSentenced with BestEntityMentionResolvedDocument[BestEntityMention]
   type BaselineTraits = OpenIELinked with ExtractedSentenced
   type FullTraits = OpenIELinked with ExtractedSentenced with BestEntityMentionsFound
-  
+
   val columnHeaders = Seq("Best Arg1", "Rel", "Best Arg2", "Original Arg1", "Original Arg2", "Sentence Text", "Arg1 Links", "Arg2 Links", "Arg1 Best Mentions", "Arg2 Best Mentions", "Doc ID", "Arg1 Changed?", "Arg2 Changed?")
 
   val columnHeaderString = columnHeaders.mkString("\t")
@@ -75,7 +75,7 @@ class EvaluationPrinter(out: java.io.PrintStream) {
     val substituted = CoreferenceResolver.substitute(indexedText, subIntervals)
     substituted.map(_._1).mkString
   }
-  
+
   def getBestDisplayMention(epart: ExtractionPart, ds: DocumentSentence[SENT], links: Seq[FreeBaseLink], bestMentions: Seq[BestEntityMention]) = {
     val subs = (links.map(_.substitution)++bestMentions.map(_.substitution))
     val filtered = getNonOverlappingSubstitutions(subs)
@@ -121,7 +121,7 @@ class EvaluationPrinter(out: java.io.PrintStream) {
       }
     }
   }
-  
+
   def printBaseline(kd: KbpDocument[_ <: Document with BaselineTraits]): Unit = {
 
     val d = kd.doc
@@ -154,7 +154,7 @@ class EvaluationPrinter(out: java.io.PrintStream) {
       }
     }
   }
-  
+
   def printCoref(kd: KbpDocument[_ <: Document with CorefTraits]): Unit = {
 
     val d = kd.doc

--- a/src/main/scala/edu/knowitall/main/KbpDocPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/KbpDocPrinter.scala
@@ -19,7 +19,7 @@ import edu.knowitall.tool.bestentitymention.BestEntityMentionsFound
  */
 class KbpDocPrinter(out: java.io.PrintStream) {
 
-  def print(kbpDoc: KbpDocument[Document with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound ]): Unit = {
+  def print(kbpDoc: KbpDocument[Document with OpenIELinked with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound ]): Unit = {
 
     val KbpDocument(doc, docId) = kbpDoc
 
@@ -47,7 +47,7 @@ class KbpDocPrinter(out: java.io.PrintStream) {
     }
   }
 
-  def printCorefClusters(doc: Document with CorefResolved[Mention]): Unit = {
+  def printCorefClusters(doc: Document with CorefResolved): Unit = {
 
     def pm(m: Mention) = s"(${m.offset}) ${m.text}"
 

--- a/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
@@ -15,7 +15,7 @@ object LinkDiffPrinter extends App {
 
   import DocOpenIEMain.loadSentencedDocs
 
-  val sentencedDocuments = loadSentencedDocs(args(0))
+  val sentencedDocuments = loadSentencedDocs(args(0))//.filter(_.docId.contains("NYT_ENG_20020724.0283.LDC2007T07"))
 
   val baseLineExtractor = new OpenIEBaselineExtractor()
   val fullExtractor = new OpenIEDocumentExtractor()
@@ -24,6 +24,7 @@ object LinkDiffPrinter extends App {
   val fullExtracted = sentencedDocuments map (kd => kd.copy(doc=fullExtractor.extract(kd.doc)))
 
   val psout = new java.io.PrintStream(args(1))
+
   val diffPrinter = new LinkDiffPrinter(psout)
   psout.println(diffPrinter.columnHeaderString)
   baseLineExtracted.zip(fullExtracted).map { case (base, full) =>
@@ -60,17 +61,18 @@ class LinkDiffPrinter(out: java.io.PrintStream) {
     }
   }
 
-  val columnHeaders = Seq("SOURCE", "OFFSET", "ORIGINAL TEXT", "WIKI TITLE", "FB ID", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE", "CONTEXT CLUSTER MENTIONS", "CONTEXT SIZE", "CONTEXT", "DOC ID")
+  val columnHeaders = Seq("SOURCE", "OFFSET", "ORIGINAL TEXT", "WIKI TITLE", "FB ID", "TYPES", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE", "CONTEXT CLUSTER MENTIONS", "CONTEXT SIZE", "CONTEXT", "DOC ID")
   val columnHeaderString = columnHeaders.mkString("\t")
 
   def diffString(old: Boolean, link: FreeBaseLink, kbpDoc: LinkedDocument): String = {
 
     val argContexts = kbpDoc.doc.argContexts.toSeq.filter { case (arg, _, ctxt) =>
-      val offsetsMatch = link.offset == arg.offset + ctxt.source.offset
+      val chStartMatch = link.offset == arg.offset + ctxt.source.offset
+      val chEndMatch = link.offset + link.text.length == arg.offset + ctxt.source.offset + arg.text.length
       val textMatch = link.text == arg.text
-      offsetsMatch && textMatch
+      chStartMatch && chEndMatch && textMatch
     }
-    require(argContexts.size == 1, "Two links different at same location with same text.")
+    require(argContexts.size == 1, s"${argContexts.size} links found, expected one.")
 
     val context = argContexts.headOption
 

--- a/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
@@ -3,6 +3,7 @@ package edu.knowitall.main
 import edu.knowitall.repr.sentence.Sentence
 import edu.knowitall.repr.document.Document
 import edu.knowitall.repr.document.Sentenced
+import edu.knowitall.tool.coref.Mention
 import edu.knowitall.tool.link.OpenIELinked
 import edu.knowitall.repr.link.FreeBaseLink
 import edu.knowitall.repr.link.Link
@@ -59,18 +60,35 @@ class LinkDiffPrinter(out: java.io.PrintStream) {
     }
   }
 
-  val columnHeaders = Seq("SOURCE", "OFFSET", "ORIGINAL TEXT", "WIKI TITLE", "FB ID", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE", "CONTEXT", "DOC ID")
+  val columnHeaders = Seq("SOURCE", "OFFSET", "ORIGINAL TEXT", "WIKI TITLE", "FB ID", "COMBINED SCORE", "DOC SIM SCORE", "INLINKS", "CROSSWIKIS SCORE", "CONTEXT CLUSTER MENTIONS", "CONTEXT SIZE", "CONTEXT", "DOC ID")
   val columnHeaderString = columnHeaders.mkString("\t")
 
   def diffString(old: Boolean, link: FreeBaseLink, kbpDoc: LinkedDocument): String = {
-    val context = kbpDoc.doc.argContexts.find { case (arg, _, context) =>
-      val offsetsMatch = link.offset == arg.offset + context.source.offset
+
+    val argContexts = kbpDoc.doc.argContexts.toSeq.filter { case (arg, _, ctxt) =>
+      val offsetsMatch = link.offset == arg.offset + ctxt.source.offset
       val textMatch = link.text == arg.text
       offsetsMatch && textMatch
     }
+    require(argContexts.size == 1, "Two links different at same location with same text.")
+
+    val context = argContexts.headOption
+
     val contextString = context.map(_._3.fullText.mkString("[", ", ", "]")).getOrElse("CONTEXT NOT FOUND")
+
+    val contextMentions = context.map { case (_, _, ctxt) =>
+      val clusters = ctxt.clusters
+      val texts = clusters.map { c =>
+        c.mentions.map { case m: Mention =>
+          s"(${m.offset}) ${m.text}"
+        }
+      }
+      texts.mkString("[", "] [", "]")
+    }.getOrElse("[]")
+    val contextSize = context.map(_._3.size).getOrElse(0)
     val diffType = if (old) "BASELINE" else "NEW"
-    diffType + "\t" + linkString(link) + "\t" + contextString + "\t" + kbpDoc.docId
+    val fields = Seq(diffType, linkString(link), contextMentions, contextSize, contextString, kbpDoc.docId)
+    fields.mkString("\t")
   }
 
   def linkString(l: Link): String = {

--- a/src/main/scala/edu/knowitall/repr/coref/Mention.scala
+++ b/src/main/scala/edu/knowitall/repr/coref/Mention.scala
@@ -14,13 +14,35 @@ trait MentionCluster[M <: Mention] {
 trait CorefResolved[M <: Mention] {
   this: Document =>
 
+  def clusters: Seq[MentionCluster[M]]
+    
   private lazy val clusterMap = clusters.flatMap(c => c.mentions.map(m => (m, c))).toMap
 
+  private lazy val mentions = clusterMap.keys.toSeq
+  
   def cluster(m: M) = clusterMap.get(m)
 
-  def clustersAt(offset: Int): Seq[MentionCluster[M]] = clusterMap.filter { case (m, c) =>
-    m.charInterval.contains(offset)
-  }.values.toSeq
+  /**
+   * Get links contained between the character interval
+   * defined by chStart (inclusive) and chEnd (exclusive)
+   */
+  def mentionsBetween(chStart: Int, chEnd: Int): Seq[M] = {
+    mentions.filter(m => m.offset >= chStart && (m.offset + m.text.length) <= chEnd)
+  }
 
-  def clusters: Seq[MentionCluster[M]]
+  /**
+   * Get links overlapping the character interval
+   * defined by chStart (inclusive) and chEnd (exclusive)
+   */
+  def mentionsIntersecting(chStart: Int, chEnd: Int): Seq[M] = {
+    mentions.filter(m => m.offset < chEnd && (m.offset + m.text.length) > chStart)
+  }
+
+  /**
+   * Get links exactly matching the character interval
+   * defined by chStart (inclusive) and chEnd (exclusive)
+   */
+  def mentionsExact(chStart: Int, chEnd: Int): Seq[M] = {
+    mentions.filter(m => m.offset == chStart && (m.offset + m.text.length) == chEnd)
+  }
 }

--- a/src/main/scala/edu/knowitall/repr/coref/Mention.scala
+++ b/src/main/scala/edu/knowitall/repr/coref/Mention.scala
@@ -9,7 +9,6 @@ import edu.knowitall.repr.tag.Tag
 trait MentionCluster[M <: Mention] {
   def best: M
   def mentions: Seq[M]
-
 }
 
 trait CorefResolvedSuperTrait {

--- a/src/main/scala/edu/knowitall/repr/coref/Mention.scala
+++ b/src/main/scala/edu/knowitall/repr/coref/Mention.scala
@@ -9,17 +9,21 @@ import edu.knowitall.repr.tag.Tag
 trait MentionCluster[M <: Mention] {
   def best: M
   def mentions: Seq[M]
+
 }
 
-trait CorefResolved[M <: Mention] {
+trait CorefResolvedSuperTrait {
+  type M <: Mention
+  def clusters: Seq[MentionCluster[M]]
+}
+
+trait CorefResolved extends CorefResolvedSuperTrait {
   this: Document =>
 
-  def clusters: Seq[MentionCluster[M]]
-    
   private lazy val clusterMap = clusters.flatMap(c => c.mentions.map(m => (m, c))).toMap
 
   private lazy val mentions = clusterMap.keys.toSeq
-  
+
   def cluster(m: M) = clusterMap.get(m)
 
   /**

--- a/src/main/scala/edu/knowitall/tool/coref/CorefResolver.scala
+++ b/src/main/scala/edu/knowitall/tool/coref/CorefResolver.scala
@@ -40,7 +40,7 @@ trait KBPRuleResolver extends CorefResolver with Linker {
   // the rule resolver takes as input a document that:
   type document = Document with
   // already has some coref info, such as from stanford
-       CorefResolved[Mention] with
+       CorefResolved with
   // and has been extracted via Open IE.
        Sentenced[Sentence with OpenIEExtracted]
 

--- a/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
+++ b/src/main/scala/edu/knowitall/tool/document/DocumentExtractor.scala
@@ -30,8 +30,8 @@ import edu.knowitall.repr.coref.MentionCluster
 class OpenIEDocumentExtractor {
 
   type InputDoc = Document with Sentenced[_ <: Sentence]
-  type OutputDoc = Document with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound
-  
+  type OutputDoc = Document with OpenIELinked with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound
+
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
@@ -51,13 +51,14 @@ class OpenIEDocumentExtractor {
     }
   }
 
-  def extract(d: Document with Sentenced[_ <: Sentence]): Document with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound = {
+  def extract(d: Document with Sentenced[_ <: Sentence]): Document with OpenIELinked with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound = {
 
     val preppedSentences = d.sentences.map { case DocumentSentence(sentence, offset) =>
       DocumentSentence(prepSentence(sentence), offset)
     }
 
-    new Document(d.text) with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound {
+    new Document(d.text) with OpenIELinked with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound {
+      type M = Mention
       val clusters = stanfordResolver.resolve(d)
       val sentences = preppedSentences
       val linker = entityLinker
@@ -70,7 +71,7 @@ class OpenIENoCorefDocumentExtractor {
 
   type InputDoc = Document with Sentenced[_ <: Sentence]
   type OutputDoc = Document with OpenIELinked with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound
-  
+
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
@@ -106,8 +107,8 @@ class OpenIENoCorefDocumentExtractor {
 class OpenIEBaselineExtractor {
 
   type InputDoc = Document with Sentenced[_ <: Sentence]
-  type OutputDoc = Document with OpenIELinked with Sentenced[Sentence with OpenIEExtracted]  
-  
+  type OutputDoc = Document with OpenIELinked with Sentenced[Sentence with OpenIEExtracted]
+
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
@@ -137,7 +138,7 @@ class OpenIEBaselineExtractor {
   }
 }
 
-class OpenIECorefExpandedDocumentExtractor {
+class OpenIECorefExpandedDocumentExtractor(val debug: Boolean = false) {
   val parser = new ClearParser()
   val chunker = new OpenNlpChunker()
   val stemmer = new MorphaStemmer()
@@ -156,7 +157,7 @@ class OpenIECorefExpandedDocumentExtractor {
       override val tokens = chunkTokens
     }
   }
-  
+
   def getUniqueLinksInCluster(cluster: MentionCluster[Mention], links : Seq[FreeBaseLink]): Seq[FreeBaseLink] = {
     var linksInCluster = Seq[FreeBaseLink]()
     for(m <- cluster.mentions){
@@ -168,7 +169,7 @@ class OpenIECorefExpandedDocumentExtractor {
     }
     linksInCluster.groupBy(f => f.id).values.map(f => f.head).toSeq
   }
-  
+
   def getUniqueBestEntityMentionsInCluster(cluster: MentionCluster[Mention], bestEntityMentions: Seq[BestEntityMention]): Seq[BestEntityMention] = {
     var bestEntityMentionsInCluster = Seq[BestEntityMention]()
     for(m <- cluster.mentions){
@@ -180,18 +181,19 @@ class OpenIECorefExpandedDocumentExtractor {
     }
     bestEntityMentionsInCluster.groupBy(f => f.bestEntityMention).values.map(f => f.head).toSeq
   }
-  
+
   def makeNewBestEntityMentionsForPronounsInCluster(cluster: MentionCluster[Mention], bestName: String) = {
     for(m <- cluster.mentions; if m.isPronoun) yield BestEntityMention(m.text,m.offset,bestName)
   }
-  
-  def extract(d: Document with Sentenced[_ <: Sentence], debug: Boolean): Document with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention] = {
+
+  def extract(d: Document with Sentenced[_ <: Sentence]): Document with LinkedDocument[FreeBaseLink] with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention] = {
 
     val preppedSentences = d.sentences.map { case DocumentSentence(sentence, offset) =>
       DocumentSentence(prepSentence(sentence), offset)
     }
 
-    val doc  = new Document(d.text) with OpenIELinked with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound {
+    val doc  = new Document(d.text) with OpenIELinked with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionsFound {
+      type M = Mention
       val clusters = stanfordResolver.resolve(d)
       val sentences = preppedSentences
       val linker = entityLinker
@@ -250,7 +252,8 @@ class OpenIECorefExpandedDocumentExtractor {
 	      }
 	    }
     }
-    val newDoc = new Document(d.text) with LinkedDocument[FreeBaseLink] with CorefResolved[Mention] with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention]{
+    val newDoc = new Document(d.text) with LinkedDocument[FreeBaseLink] with CorefResolved with Sentenced[Sentence with OpenIEExtracted] with BestEntityMentionResolvedDocument[BestEntityMention]{
+      type M = Mention
       val links = doc.links
       val clusters = doc.clusters
       val sentences = doc.sentences

--- a/src/main/scala/edu/knowitall/tool/link/Linker.scala
+++ b/src/main/scala/edu/knowitall/tool/link/Linker.scala
@@ -64,7 +64,7 @@ trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
    */
   lazy val argContexts = this.sentences.flatMap { s =>
     // Get arguments to send to the linker
-    val args = s.sentence.extractions.flatMap(e => e.arg1 :: e.arg2 :: Nil)
+    val args = s.sentence.extractions.flatMap(e => e.arg1 :: e.arg2 :: Nil).distinct
     val cleanArgs = args map cleanArg(s.sentence)
 
     // Get context and cleaned-up form for each arg

--- a/src/main/scala/edu/knowitall/tool/link/Linker.scala
+++ b/src/main/scala/edu/knowitall/tool/link/Linker.scala
@@ -59,9 +59,12 @@ trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
     val args = s.sentence.extractions.flatMap(e => e.arg1 :: e.arg2 :: Nil)
     val cleanArgs = args map cleanArg(s.sentence)
     args.zip(cleanArgs).map { case (arg, cleaned) =>
-      val ao = s.sentence.tokens(arg.tokenIndices.head).offset + s.offset
       val extended = if (this.isInstanceOf[CorefResolved[_ <: Mention]]) {
-        val otherMentions = this.asInstanceOf[CorefResolved[_ <: Mention]].clustersAt(ao).flatMap(_.mentions)
+        val argStartToken = s.sentence.tokens(arg.tokenIndices.head)
+        val argEndToken = s.sentence.tokens(arg.tokenIndices.last)
+        val chStart = argStartToken.offset + s.offset
+        val chEnd = argEndToken.offset + argEndToken.string.length + s.offset
+        val otherMentions = this.asInstanceOf[CorefResolved[_ <: Mention]].mentionsBetween(chStart, chEnd)
         otherMentions.map(_.offset).flatMap(sentenceAt).toList
       } else Nil
       val context = Context(s, extended)

--- a/src/main/scala/edu/knowitall/tool/link/Linker.scala
+++ b/src/main/scala/edu/knowitall/tool/link/Linker.scala
@@ -43,11 +43,11 @@ trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
     def size = extended.size + 1 // +1 for the required source field.
   }
 
-  private def sentenceAt(offset: Int): Option[DocumentSentence[Sentence with OpenIEExtracted]] = {
+  private def sentenceContaining(chStart: Int, chEnd: Int): Option[DocumentSentence[Sentence with OpenIEExtracted]] = {
     this.sentences.find { s =>
-      val charStart = s.offset
-      val charEnd   = s.offset + s.sentence.text.length
-      offset >= charStart && offset <= charEnd
+      val sStart = s.offset
+      val sEnd   = s.offset + s.sentence.text.length
+      chStart >= sStart && chEnd <= sEnd
     }
   }
 
@@ -78,7 +78,9 @@ trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
         def otherMentions = thisCoref.mentionsBetween(chStart, chEnd).map(_.asInstanceOf[thisCoref.M])
         val otherClusters = otherMentions.flatMap(thisCoref.cluster)
         val otherClusterMentions = otherClusters.flatMap(_.mentions)
-        val extended = otherClusterMentions.map(_.offset).flatMap(sentenceAt).toList
+        val extended = otherClusterMentions.flatMap { m =>
+          sentenceContaining(m.offset, m.offset + m.text.length)
+        }
         (extended, otherClusters)
       } else {
         (Nil, Nil)


### PR DESCRIPTION
Also -- Changed trait CorefResolved to use a type bound ( type M <: Mention ) rather than a type parameter. This made it possible to know what the mention type was within the linker for the purpose of finding the parent MentionCluster.

Also moved the debug option on OpenIECorefExpandedDocumentExtractor.extract to be a constructor field that defaults to false -- that way all extractors still have the same interface. 
