### PR TITLE
Use best-mention info in linker and fix extraction diff bug

### DIFF
--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -56,7 +56,7 @@ object DocOpenIEMain {
   */
   def main(args: Array[String]): Unit = Timing.timeThen {
 
-    val sentencedDocuments = loadSentencedDocs(args(0)).take(1)
+    val sentencedDocuments = loadSentencedDocs(args(0))
 
     val baselineSystem = new OpenIEBaselineExtractor()
     val comparisonSystem = new OpenIEDocumentExtractor()

--- a/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
+++ b/src/main/scala/edu/knowitall/main/DocOpenIEMain.scala
@@ -67,7 +67,7 @@ object DocOpenIEMain {
     val evalPrinter = new EvaluationPrinter(psout)
     evalPrinter.printColumnHeaderString()
     extractedDocuments.foreach { ed =>
-      evalPrinter.printCoref(ed)
+      evalPrinter.printFull(ed)
     }
     psout.flush()
     System.err.println("Total extractions: " + extractedDocuments.flatMap(_.doc.sentences.map(_.sentence.extractions)).size)

--- a/src/main/scala/edu/knowitall/main/EvaluationPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/EvaluationPrinter.scala
@@ -91,7 +91,7 @@ class EvaluationPrinter(out: java.io.PrintStream) {
     else {
       val eOffset = offset(epart, ds)
       val indexedText = epart.text.zipWithIndex.map(p => (p._1, p._2+eOffset))
-      val fixedSubs = subs.map(_.fixPossessive)
+      val fixedSubs = filtered.map(_.fixPossessive)
       val subIntervals = fixedSubs.map { s => (Interval.open(s.mention.offset, s.mention.offset + s.mention.text.length), s.best.text) }
       val substituted = CoreferenceResolver.substitute(indexedText, subIntervals)
       substituted.map(_._1).mkString

--- a/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
+++ b/src/main/scala/edu/knowitall/main/LinkDiffPrinter.scala
@@ -89,20 +89,15 @@ class LinkDiffPrinter(out: java.io.PrintStream) {
     }.getOrElse("[]")
     val contextSize = context.map(_._3.size).getOrElse(0)
     val diffType = if (old) "BASELINE" else "NEW"
-    val fields = Seq(diffType, linkString(link), contextMentions, contextSize, contextString, kbpDoc.docId)
-    fields.mkString("\t")
+    val fields = Seq(diffType) ++ linkFields(link) ++ Seq(contextMentions, contextSize.toString, contextString, kbpDoc.docId)
+    fields.map(EvaluationPrinter.clean).mkString("\t")
   }
 
-  def linkString(l: Link): String = {
+  def linkFields(f: FreeBaseLink): Seq[String] = {
 
     def fmt(d: Double) = "%.02f" format d
-
-    l match {
-        case f: FreeBaseLink =>
-          val types = f.types.take(2).mkString(", ") + { if (f.types.size > 2) ", ..." else "" }
-          val fields = Seq(f.offset, f.text, f.name, f.id, types, fmt(f.score), fmt(f.docSimScore), fmt(f.inlinks), fmt(f.candidateScore))
-          fields.mkString("\t")
-        case _ => s"(l.offset)\t${l.toString}"
-    }
+    val types = f.types.take(2).mkString(", ") + { if (f.types.size > 2) ", ..." else "" }
+    val fields = Seq(f.offset.toString, f.text, f.name, f.id, types, fmt(f.score), fmt(f.docSimScore), fmt(f.inlinks), fmt(f.candidateScore))
+    fields
   }
 }

--- a/src/main/scala/edu/knowitall/prep/Sentencer.scala
+++ b/src/main/scala/edu/knowitall/prep/Sentencer.scala
@@ -33,7 +33,7 @@ class Sentencer private (val segmenter: Segmenter) {
     }
   }
 
-  private val newLine = Pattern.compile("\n")
+  private val newLine = Pattern.compile("\n|\t")
 
   private def buildParagraphs(lineIterator: Iterator[KbpDocLine]): Seq[KbpDocLine] = {
     val lineGroups = Iterator.continually {

--- a/src/main/scala/edu/knowitall/repr/bestentitymention/BestEntityMention.scala
+++ b/src/main/scala/edu/knowitall/repr/bestentitymention/BestEntityMention.scala
@@ -26,8 +26,10 @@ object BestEntityMention{
 	  BestEntityMentionImpl(text,offset,bestEntityMention)
   }
 }
-trait BestEntityMentionResolvedDocument[B <: BestEntityMention]{
+trait BestEntityMentionResolvedDocument {
   this: Document =>
+
+  type B <: BestEntityMention
 
   def bestEntityMentions: Seq[B];
 

--- a/src/main/scala/edu/knowitall/repr/bestentitymention/BestEntityMention.scala
+++ b/src/main/scala/edu/knowitall/repr/bestentitymention/BestEntityMention.scala
@@ -8,11 +8,15 @@ import edu.knowitall.tool.coref.Substitution
 trait BestEntityMention extends Tag {
   def bestEntityMention: String
   require(bestEntityMention != this.text, "Best Entity Mention annotations should always differ from the text they are annotating")
-  
+
   def substitution = {
     val original = Mention(this.text, this.offset)
     val best = Mention(this.bestEntityMention, this.offset)
     Substitution(original, best)
+  }
+
+  def debugString: String = {
+    s"($offset) $text -> $bestEntityMention"
   }
 }
 

--- a/src/main/scala/edu/knowitall/repr/link/Link.scala
+++ b/src/main/scala/edu/knowitall/repr/link/Link.scala
@@ -32,13 +32,12 @@ object FreeBaseLink {
   def apply(text: String, offset: Int, name: String, score: Double, docSimScore: Double, candidateScore: Double, inlinks: Double, id: String, types: Seq[String]) = FreeBaseLinkImpl(text, offset, name, score, docSimScore, candidateScore, inlinks, id, types)
 }
 
-trait LinkedDocument[L <: Link] {
+trait LinkedDocument {
   this: Document =>
 
+  type L <: Link
+
   def links: Seq[L]
-
-
-
 
   /**
    * Get links contained between the character interval

--- a/src/main/scala/edu/knowitall/repr/link/Link.scala
+++ b/src/main/scala/edu/knowitall/repr/link/Link.scala
@@ -7,6 +7,7 @@ import edu.knowitall.tool.coref.Mention
 
 trait Link extends Tag {
   def name: String
+  def id: String
   def score: Double
 
   def substitution = {
@@ -14,6 +15,8 @@ trait Link extends Tag {
     val best = Mention(this.name, this.offset)
     Substitution(original, best)
   }
+
+  def debugString = Seq(name, id, score).mkString("(", ",", ")")
 }
 
 trait FreeBaseLink extends Link {

--- a/src/main/scala/edu/knowitall/tool/bestentitymention/BestEntityMentionFinder.scala
+++ b/src/main/scala/edu/knowitall/tool/bestentitymention/BestEntityMentionFinder.scala
@@ -24,8 +24,10 @@ trait BestEntityMentionFinder{
 }
 
 
-trait BestEntityMentionsFound extends BestEntityMentionResolvedDocument[BestEntityMention]{
+trait BestEntityMentionsFound extends BestEntityMentionResolvedDocument {
   this: Document  =>
+
+  override type B = BestEntityMention
 
   private lazy val NERAnnotator = {
     	val nerProperties = new Properties();
@@ -579,7 +581,6 @@ object BestEntityMentionFinderOriginalAlgorithm{
 
   val provinceCityMap = scala.collection.mutable.Map[String,Set[String]]()
   val countryCityMap = scala.collection.mutable.Map[String,Set[String]]()
-
 
   // read in tipster lines with latin encoding so as not to get errors.
   scala.io.Source.fromFile(tipsterFile.getPath())(scala.io.Codec.ISO8859).getLines.foreach(line => {

--- a/src/main/scala/edu/knowitall/tool/link/Linker.scala
+++ b/src/main/scala/edu/knowitall/tool/link/Linker.scala
@@ -1,16 +1,20 @@
 package edu.knowitall.tool.link
 
+import edu.knowitall.collection.immutable.Interval
 import edu.knowitall.repr.sentence.Sentence
 import edu.knowitall.repr.sentence.Postagged
 import edu.knowitall.repr.sentence.Chunked
 import edu.knowitall.tool.sentence.OpenIEExtracted
 import edu.knowitall.tool.coref.CorefResolver
+import edu.knowitall.repr.bestentitymention.BestEntityMentionResolvedDocument
 import edu.knowitall.repr.link.Link
 import edu.knowitall.repr.link.FreeBaseLink
 import edu.knowitall.repr.coref.CorefResolved
 import edu.knowitall.repr.extraction.ExtractionPart
 import edu.knowitall.tool.coref.Mention
 import edu.knowitall.repr.coref.MentionCluster
+import edu.knowitall.tool.coref.Substitution
+import edu.knowitall.tool.coref.CoreferenceResolver
 import edu.knowitall.repr.link.LinkedDocument
 import edu.knowitall.repr.document.Document
 import edu.knowitall.repr.document.DocumentSentence
@@ -26,7 +30,6 @@ trait Linker {
 
   def link(doc: document): Seq[link]
 }
-
 
 trait OpenIELinked extends LinkedDocument {
   this: Document with Sentenced[Sentence with OpenIEExtracted] =>
@@ -53,12 +56,53 @@ trait OpenIELinked extends LinkedDocument {
     }
   }
 
-  private def cleanArg(sent: Sentence with Chunked)(arg: ExtractionPart): String = {
-    var tokens = arg.tokenIndices.map(index => sent.tokens(index))
+  private def cleanArg(sent: DocumentSentence[Sentence with OpenIEExtracted])(arg: ExtractionPart): Seq[(Char, Int)] = {
+    var tokens = arg.tokenIndices.map(index => sent.sentence.tokens(index))
     // drop determiners and prepositions from start/end
     if (tokens.headOption.exists(t => t.isDeterminer || t.isPreposition)) tokens = tokens.drop(1)
     if (tokens.lastOption.exists(t => t.isDeterminer || t.isPreposition)) tokens = tokens.dropRight(1)
-    tokens.map(_.string).mkString(" ")
+    tokens.flatMap { t =>
+      val baseOffset = t.offset + sent.offset
+      t.string.zipWithIndex.map { case (ch, index) => (ch, index + baseOffset) } :+ (' ', baseOffset + t.string.length)
+    }.dropRight(1)
+  }
+
+  /**
+   * iterate over subs and remove any Substitutions, by their interval, that overlap with earlier subs.
+   * e.g. ([0,1], [1,2], [2,3]) -> ([0,1], [2,3])
+   */
+  private def getNonOverlappingSubstitutions(subs: Seq[Substitution]): Seq[Substitution] = {
+    var subsToKeep = List.empty[Substitution]
+    var usedIntervals = List.empty[Interval]
+    for (s <- subs) {
+      val sInterval = Interval.open(s.mention.offset, s.mention.offset + s.mention.text.length)
+      if (!usedIntervals.exists(_.intersects(sInterval))) {
+        usedIntervals ::= sInterval
+        subsToKeep ::= s
+      }
+    }
+    subsToKeep
+  }
+
+
+  private def resolveArg(indexedText: Seq[(Char, Int)], ds: DocumentSentence[Sentence with OpenIEExtracted]) = {
+    val bestMentions = if (this.isInstanceOf[BestEntityMentionResolvedDocument]) {
+      (indexedText.headOption, indexedText.lastOption) match {
+        case (Some((_, chStart)), Some((_, chEnd))) =>
+          this.asInstanceOf[BestEntityMentionResolvedDocument].bestEntityMentionsBetween(indexedText.head._2, indexedText.last._2 + 1)
+        case _ => Nil
+      }
+
+    } else Nil
+    val subs = bestMentions.map(_.substitution)
+    val filtered = getNonOverlappingSubstitutions(subs)
+    if (filtered.isEmpty) indexedText.map(_._1).mkString
+    else {
+      val fixedSubs = filtered.map(_.fixPossessive)
+      val subIntervals = fixedSubs.map { s => (Interval.open(s.mention.offset, s.mention.offset + s.mention.text.length), s.best.text) }
+      val substituted = CoreferenceResolver.substitute(indexedText, subIntervals)
+      substituted.map(_._1).mkString
+    }
   }
 
   /**
@@ -67,10 +111,11 @@ trait OpenIELinked extends LinkedDocument {
   lazy val argContexts = this.sentences.flatMap { s =>
     // Get arguments to send to the linker
     val args = s.sentence.extractions.flatMap(e => e.arg1 :: e.arg2 :: Nil).distinct
-    val cleanArgs = args map cleanArg(s.sentence)
-
+    val cleanArgs = args map cleanArg(s)
+    val resolvedArgs = cleanArgs.map(ca => resolveArg(ca, s))
+    val foo = 1
     // Get context and cleaned-up form for each arg
-    args.zip(cleanArgs).map { case (arg, cleaned) =>
+    args.zip(resolvedArgs).map { case (arg, cleaned) =>
       val (extended, clusters) = if (this.isInstanceOf[CorefResolved]) {
         val argStartToken = s.sentence.tokens(arg.tokenIndices.head)
         val argEndToken = s.sentence.tokens(arg.tokenIndices.last)

--- a/src/main/scala/edu/knowitall/tool/link/Linker.scala
+++ b/src/main/scala/edu/knowitall/tool/link/Linker.scala
@@ -28,8 +28,10 @@ trait Linker {
 }
 
 
-trait OpenIELinked extends LinkedDocument[FreeBaseLink] {
+trait OpenIELinked extends LinkedDocument {
   this: Document with Sentenced[Sentence with OpenIEExtracted] =>
+
+  override type L = FreeBaseLink
 
   // Hardcoded threshold for linker score.
   val minCombinedScore = 4.5


### PR DESCRIPTION
Linker now checks if document.isInstanceOf[BestEntityMentionResolvedDocument], and uses that info if it is.

Fixed the problem where linked extractions were displayed as new (diff from baseline) even if baseline had the same link. 

Re-organized DocumentExtractor to factor out most of the common code.
Changed several more traits from type-parameterized to type-bounded because it makes it possible to do .isInstanceOf checks and then use that trait's info.
